### PR TITLE
Update addForkMode for Maven 2.14+

### DIFF
--- a/src/krasa/mavenrun/action/debug/DebugConfigurationAction.java
+++ b/src/krasa/mavenrun/action/debug/DebugConfigurationAction.java
@@ -45,6 +45,6 @@ public class DebugConfigurationAction extends RunConfigurationAction {
 
 	private void addForkMode(RunnerAndConfigurationSettings configSettings) {
 		MavenRunConfiguration mavenRunConfiguration = (MavenRunConfiguration) configSettings.getConfiguration();
-		mavenRunConfiguration.getRunnerParameters().getGoals().add("-DforkMode=never");
+		mavenRunConfiguration.getRunnerParameters().getGoals().add("-DforkMode=never -DforkCount=0 -DreuseForks=false");
 	}
 }


### PR DESCRIPTION
Adds forkMode and resuseForks to the commandline when debugging to avoid those being overriden by values set in the POM that would be used during a normal (not debug) test run

to resolve #4 