### PR TITLE
Fixed searching in tree mode, and made searching case insensitive.

### DIFF
--- a/src/krasa/mavenhelper/analyzer/GuiForm.java
+++ b/src/krasa/mavenhelper/analyzer/GuiForm.java
@@ -57,10 +57,10 @@ public class GuiForm {
 			+ "-use IJ 2016.1+ and configure it to use external Maven 3.1.1+ (File | Settings | Build, Execution, Deployment | Build Tools | Maven | Maven home directory)\n"
 			+ "-press Apply Fix button to alter Maven VM options for importer (might cause trouble for IJ 2016.1+)\n"
 			+ "-turn off File | Settings | Build, Execution, Deployment | Build Tools | Maven | Importing | Use Maven3 to import project setting\n";
-	protected static final Comparator<MavenArtifactNode> BY_ARTICATF_ID = new Comparator<MavenArtifactNode>() {
+	protected static final Comparator<MavenArtifactNode> BY_ARTIFACT_ID = new Comparator<MavenArtifactNode>() {
 		@Override
 		public int compare(MavenArtifactNode o1, MavenArtifactNode o2) {
-      return o1.getArtifact().getArtifactId().toLowerCase().compareTo(o2.getArtifact().getArtifactId().toLowerCase());
+			return o1.getArtifact().getArtifactId().toLowerCase().compareTo(o2.getArtifact().getArtifactId().toLowerCase());
 		}
 	};
 	private static final String LAST_RADIO_BUTTON = "MavenHelper.lastRadioButton";
@@ -347,7 +347,7 @@ public class GuiForm {
 			for (Map.Entry<String, List<MavenArtifactNode>> s : allArtifactsMap.entrySet()) {
 				final List<MavenArtifactNode> nodes = s.getValue();
 				if (nodes.size() > 1 && hasConflicts(nodes)) {
-					if (searchFieldText == null || s.getKey().toLowerCase().contains(searchFieldText.toLowerCase())) {
+					if (contains(searchFieldText, s.getKey())) {
 						listDataModel.addElement(new MyListNode(s));
 					}
 				}
@@ -399,7 +399,7 @@ public class GuiForm {
 			leftPanelLayout.show(leftPanelWrapper, "list");
 		} else if (allDependenciesAsListRadioButton.isSelected()) {
 			for (Map.Entry<String, List<MavenArtifactNode>> s : allArtifactsMap.entrySet()) {
-				if (searchFieldText == null || s.getKey().toLowerCase().contains(searchFieldText.toLowerCase())) {
+				if (contains(searchFieldText, s.getKey())) {
 					listDataModel.addElement(new MyListNode(s));
 				}
 			}
@@ -430,7 +430,7 @@ public class GuiForm {
 
 	private boolean fillLeftTree(DefaultMutableTreeNode parent, List<MavenArtifactNode> dependencyTree, String searchFieldText) {
 		boolean search = StringUtils.isNotBlank(searchFieldText);
-		Collections.sort(dependencyTree, BY_ARTICATF_ID);
+		Collections.sort(dependencyTree, BY_ARTIFACT_ID);
 		boolean hasAddedNodes = false;
 
 		for (MavenArtifactNode mavenArtifactNode : dependencyTree) {
@@ -454,8 +454,11 @@ public class GuiForm {
 
 	private boolean contains(String searchFieldText, MavenArtifactNode mavenArtifactNode) {
 		MavenArtifact artifact = mavenArtifactNode.getArtifact();
-		String displayStringSimple = getArtifactKey(artifact);
-		return displayStringSimple.toLowerCase().contains(searchFieldText.toLowerCase());
+		return contains(searchFieldText, getArtifactKey(artifact));
+	}
+
+	private boolean contains(String searchFieldText, String artifactKey) {
+		return StringUtils.isBlank(searchFieldText) || StringUtils.containsIgnoreCase(artifactKey, searchFieldText);
 	}
 
 	private boolean hasConflicts(List<MavenArtifactNode> nodes) {


### PR DESCRIPTION
When searching in tree mode, the selection process will in some conditions return extra unmatched nodes.
This PR makes search in tree mode return only matched nodes, and their respective parents.
It now works more closely to how Eclipse filters results.
Also, searching is now case insensitive.
Please let me know if you feel any adjustments are needed to have this merged.
Thanks to @vieira for the help.