### PR TITLE
model: Goal command with proper cmdline tokenizer

### DIFF
--- a/src/main/java/krasa/mavenhelper/model/Goal.java
+++ b/src/main/java/krasa/mavenhelper/model/Goal.java
@@ -1,6 +1,7 @@
 package krasa.mavenhelper.model;
 
 import com.intellij.execution.actions.ConfigurationContext;
+import com.intellij.execution.configurations.CommandLineTokenizer;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.containers.ContainerUtil;
@@ -36,6 +37,6 @@ public class Goal extends DomainObject {
 		String cmd = getCommandLine();
 		cmd = ApplicationSettings.get().applyAliases(cmd, psiFile, configurationContext);
 
-		return ContainerUtil.newArrayList(StringUtil.tokenize(new StringTokenizer(cmd)));
+		return ContainerUtil.newArrayList(StringUtil.tokenize(new CommandLineTokenizer(cmd)));
 	}
 }


### PR DESCRIPTION
This resolves -Da="arg1 arg2" resulting in arg2 being tokenized.

I didn't spend too much time on this, so maybe there's more, but this seems to resolve the main issue.