### PR TITLE
Added search background color settings and conflict foreground color …

### DIFF
--- a/src/main/java/krasa/mavenhelper/analyzer/GuiForm.java
+++ b/src/main/java/krasa/mavenhelper/analyzer/GuiForm.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.*;
 import com.intellij.ui.components.JBList;
+import krasa.mavenhelper.ApplicationService;
 import krasa.mavenhelper.Donate;
 import krasa.mavenhelper.MyProjectService;
 import krasa.mavenhelper.analyzer.action.LeftTreePopupHandler;
@@ -133,7 +134,7 @@ public class GuiForm implements Disposable {
 			"  </body>\n" +
 			"</html>\n");
 		intellijBugLabel.setBackground(rootPanel.getBackground());
-		intellijBugLabel.setForeground(SimpleTextAttributes.ERROR_ATTRIBUTES.getFgColor());
+		intellijBugLabel.setForeground(ApplicationService.getInstance().getState().getErrorAttributes().getFgColor());
 		intellijBugLabel.setVisible(false);
 		intellijBugLabel.addHyperlinkListener(e -> {
 			if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
@@ -151,7 +152,7 @@ public class GuiForm implements Disposable {
 			"  </body>\n" +
 			"</html>\n");
 		falsePositive.setBackground(rootPanel.getBackground());
-		falsePositive.setForeground(SimpleTextAttributes.ERROR_ATTRIBUTES.getFgColor());
+		falsePositive.setForeground(ApplicationService.getInstance().getState().getErrorAttributes().getFgColor());
 		falsePositive.setVisible(false);
 		falsePositive.addHyperlinkListener(e -> {
 			if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
@@ -212,7 +213,7 @@ public class GuiForm implements Disposable {
 
 		noConflictsWarningLabel.setBackground(null);
 		noConflictsWarningLabel.setText(WARNING);
-		noConflictsWarningLabel.setForeground(SimpleTextAttributes.ERROR_ATTRIBUTES.getFgColor());
+		noConflictsWarningLabel.setForeground(ApplicationService.getInstance().getState().getErrorAttributes().getFgColor());
 
 		leftPanelLayout = (CardLayout) leftPanelWrapper.getLayout();
 
@@ -273,7 +274,7 @@ public class GuiForm implements Disposable {
 		actionGroup.add(CommonActionsManager.getInstance().createCollapseAllAction(treeExpander, leftTree));
 		ActionToolbar actionToolbar = ActionManagerEx.getInstance().createActionToolbar("krasa.MavenHelper.buttons", actionGroup, true);
 		buttonsPanel.add(actionToolbar.getComponent(), "1");
-		errorBoldAttributes = new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, SimpleTextAttributes.ERROR_ATTRIBUTES.getFgColor());
+		errorBoldAttributes = new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, ApplicationService.getInstance().getState().getErrorAttributes().getFgColor());
 
 		String lastRadioButton = PropertiesComponent.getInstance().getValue(LAST_RADIO_BUTTON);
 		if ("tree".equals(lastRadioButton)) {
@@ -327,7 +328,7 @@ public class GuiForm implements Disposable {
 				SimpleTextAttributes attributes = SimpleTextAttributes.REGULAR_ATTRIBUTES;
 				SimpleTextAttributes boldAttributes = SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES;
 				if (conflict && allDependenciesAsListRadioButton.isSelected()) {
-					attributes = SimpleTextAttributes.ERROR_ATTRIBUTES;
+					attributes = ApplicationService.getInstance().getState().getErrorAttributes();
 					boldAttributes = errorBoldAttributes;
 				}
 				if (showSize.isSelected()) {

--- a/src/main/java/krasa/mavenhelper/analyzer/MyHighlightingTree.java
+++ b/src/main/java/krasa/mavenhelper/analyzer/MyHighlightingTree.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.treeStructure.Tree;
 import com.intellij.util.ui.UIUtil;
+import krasa.mavenhelper.ApplicationService;
 import krasa.mavenhelper.analyzer.action.BaseAction;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.project.MavenProject;
@@ -34,9 +35,9 @@ public class MyHighlightingTree extends Tree implements DataProvider {
 		if (object instanceof MyTreeUserObject) {
 			if (((MyTreeUserObject) object).isHighlight()) {
 				if (UIUtil.isUnderDarcula()) {
-					return darker(JBColor.CYAN, 8);
+					return darker(new JBColor(new Color(ApplicationService.getInstance().getState().getSearchBackgroundColor()), new Color(ApplicationService.getInstance().getState().getSearchBackgroundColor())), 8);
 				} else {
-					return softer(Color.CYAN);
+					return softer(new JBColor(new Color(ApplicationService.getInstance().getState().getSearchBackgroundColor()), new Color(ApplicationService.getInstance().getState().getSearchBackgroundColor())));
 				}
 			}
 		}

--- a/src/main/java/krasa/mavenhelper/analyzer/TreeRenderer.java
+++ b/src/main/java/krasa/mavenhelper/analyzer/TreeRenderer.java
@@ -3,6 +3,7 @@ package krasa.mavenhelper.analyzer;
 import com.intellij.ui.ColoredTreeCellRenderer;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.SimpleTextAttributes;
+import krasa.mavenhelper.ApplicationService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.model.MavenArtifact;
@@ -21,7 +22,6 @@ public class TreeRenderer extends ColoredTreeCellRenderer {
 	private final JCheckBox showGroupId;
 	private final JCheckBox showSize;
 	private final GuiForm guiForm;
-	private final SimpleTextAttributes errorBoldAttributes;
 
 	private final SimpleTextAttributes testAttributes;
 	private final SimpleTextAttributes testBoldAttributes;
@@ -31,13 +31,12 @@ public class TreeRenderer extends ColoredTreeCellRenderer {
 
 	private final SimpleTextAttributes runtimeAttributes;
 	private final SimpleTextAttributes runtimeBoldAttributes;
-	public static final SimpleTextAttributes ERROR_BOLD = SimpleTextAttributes.ERROR_ATTRIBUTES.derive(SimpleTextAttributes.STYLE_BOLD, null, null, null);
+	public static final SimpleTextAttributes ERROR_BOLD = ApplicationService.getInstance().getState().getErrorAttributes().derive(SimpleTextAttributes.STYLE_BOLD, null, null, null);
 
 	public TreeRenderer(JCheckBox showGroupId, JCheckBox showSize, GuiForm guiForm) {
 		this.showGroupId = showGroupId;
 		this.showSize = showSize;
 		this.guiForm = guiForm;
-		errorBoldAttributes = new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, SimpleTextAttributes.ERROR_ATTRIBUTES.getFgColor());
 
 		testAttributes = new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, new JBColor(new Color(4, 111, 0), new Color(0x69AF80)));
 		testBoldAttributes = new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, testAttributes.getFgColor());
@@ -79,7 +78,7 @@ public class TreeRenderer extends ColoredTreeCellRenderer {
 		if (myTreeUserObject.showOnlyVersion) {
 			SimpleTextAttributes attributes = SimpleTextAttributes.REGULAR_ATTRIBUTES;
 			if (error) {
-				attributes = SimpleTextAttributes.ERROR_ATTRIBUTES;
+				attributes = ApplicationService.getInstance().getState().getErrorAttributes();
 			}
 			append(currentVersion + " [" + classifier + artifact.getScope() + "]", attributes);
 
@@ -91,8 +90,8 @@ public class TreeRenderer extends ColoredTreeCellRenderer {
 			SimpleTextAttributes attributes;
 			SimpleTextAttributes boldAttributes;
 			if (error) {
-				attributes = SimpleTextAttributes.ERROR_ATTRIBUTES;
-				boldAttributes = errorBoldAttributes;
+				attributes = ApplicationService.getInstance().getState().getErrorAttributes();
+				boldAttributes = ApplicationService.getInstance().getState().getErrorBoldAttributes();
 			} else if ("test".equals(myTreeUserObject.getArtifact().getScope())) {
 				attributes = testAttributes;
 				boldAttributes = testBoldAttributes;

--- a/src/main/java/krasa/mavenhelper/gui/AliasTable.java
+++ b/src/main/java/krasa/mavenhelper/gui/AliasTable.java
@@ -26,7 +26,7 @@ public class AliasTable extends JBTable {
 
 	private final List<Alias> myAliases = new ArrayList<>();
 
-	public AliasTable() {
+	public AliasTable(ApplicationSettings original) {
 		setModel(myTableModel);
 		TableColumn column = getColumnModel().getColumn(NAME_COLUMN);
 		column.setCellRenderer(new DefaultTableCellRenderer() {
@@ -35,7 +35,7 @@ public class AliasTable extends JBTable {
 				final Component component = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 				final String macroValue = getAliasValueAt(row);
 				component.setForeground(macroValue.length() == 0
-					? JBColor.RED
+					? new JBColor(original.getConflictsForegroundColor(), original.getConflictsForegroundColor())
 					: isSelected ? table.getSelectionForeground() : table.getForeground());
 				return component;
 			}

--- a/src/main/java/krasa/mavenhelper/gui/ApplicationSettingsForm.form
+++ b/src/main/java/krasa/mavenhelper/gui/ApplicationSettingsForm.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="krasa.mavenhelper.gui.ApplicationSettingsForm">
-  <grid id="27dc6" binding="rootComponent" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootComponent" layout-manager="GridLayoutManager" row-count="7" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="687" height="400"/>
+      <xy x="20" y="20" width="922" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -11,7 +11,7 @@
       <grid id="c7968" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -48,14 +48,14 @@
       </grid>
       <component id="e8e7b" class="javax.swing.JSeparator">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <grid id="aa489" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -82,7 +82,7 @@
       </grid>
       <splitpane id="ab807" binding="split">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="4" column="0" row-span="1" col-span="5" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <preferred-size width="200" height="200"/>
           </grid>
         </constraints>
@@ -149,7 +149,7 @@
       </splitpane>
       <component id="1d557" class="javax.swing.JCheckBox" binding="enableDelete">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Enable Delete key in &quot;Run Maven Goal&quot; popups"/>
@@ -157,13 +157,50 @@
       </component>
       <component id="76825" class="javax.swing.JCheckBox" binding="resolveWorkspaceArtifactsCheckBox" default-binding="true">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Resolve workspace artifacts"/>
           <toolTipText value="In case of multi-project workspace,dependencies will be looked for in the workspace first, and only after that in local repository"/>
         </properties>
       </component>
+      <component id="ea631" class="javax.swing.JLabel" binding="searchBackgroundColorNameLabel">
+        <constraints>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Search Background Color"/>
+        </properties>
+      </component>
+      <component id="bc267" class="javax.swing.JLabel" binding="searchBackgroundColorPickerLabel">
+        <constraints>
+          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value=""/>
+        </properties>
+      </component>
+      <component id="c1593" class="javax.swing.JLabel" binding="conflictsForegroundColorNameLabel">
+        <constraints>
+          <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Conflicts Foreground Color"/>
+        </properties>
+      </component>
+      <component id="ac624" class="javax.swing.JLabel" binding="conflictsForegroundColorPickerLabel">
+        <constraints>
+          <grid row="6" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value=""/>
+        </properties>
+      </component>
+      <hspacer id="50510">
+        <constraints>
+          <grid row="6" column="4" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
     </children>
   </grid>
 </form>

--- a/src/main/java/krasa/mavenhelper/gui/ApplicationSettingsForm.java
+++ b/src/main/java/krasa/mavenhelper/gui/ApplicationSettingsForm.java
@@ -5,9 +5,12 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.ui.AnActionButton;
 import com.intellij.ui.AnActionButtonRunnable;
+import com.intellij.ui.ColorPicker;
 import com.intellij.ui.DoubleClickListener;
+import com.intellij.ui.JBColor;
 import com.intellij.ui.ToolbarDecorator;
 import com.intellij.ui.components.JBList;
+import java.util.ArrayList;
 import krasa.mavenhelper.Donate;
 import krasa.mavenhelper.model.ApplicationSettings;
 import krasa.mavenhelper.model.Goal;
@@ -42,13 +45,17 @@ public class ApplicationSettingsForm {
 	private JSplitPane split;
 	private JCheckBox enableDelete;
 	private JCheckBox resolveWorkspaceArtifactsCheckBox;
+	private JLabel searchBackgroundColorNameLabel;
+	private JLabel searchBackgroundColorPickerLabel;
+	private JLabel conflictsForegroundColorNameLabel;
+	private JLabel conflictsForegroundColorPickerLabel;
 
 	protected JBList focusedComponent;
 	private AliasTable aliasTable;
 
 	public ApplicationSettingsForm(ApplicationSettings original) {
 		this.settings = original.clone();
-		aliasTable = new AliasTable();
+		aliasTable = new AliasTable(this.settings);
 		myPathVariablesPanel.add(
 			ToolbarDecorator.createDecorator(aliasTable)
 				.setAddAction(new AnActionButtonRunnable() {
@@ -164,6 +171,44 @@ public class ApplicationSettingsForm {
 
 		useIgnoredPoms.setSelected(this.settings.isUseIgnoredPoms());
 		Donate.init(rootComponent, donate);
+
+		searchBackgroundColorPickerLabel.setPreferredSize(new Dimension(20, 20));
+		searchBackgroundColorPickerLabel.setOpaque(true);
+		searchBackgroundColorPickerLabel.setBackground(new JBColor(new Color(settings.getSearchBackgroundColor()), new Color(settings.getSearchBackgroundColor())));
+
+		conflictsForegroundColorPickerLabel.setPreferredSize(new Dimension(20, 20));
+		conflictsForegroundColorPickerLabel.setOpaque(true);
+		conflictsForegroundColorPickerLabel.setBackground(new JBColor(new Color(settings.getConflictsForegroundColor()), new Color(settings.getConflictsForegroundColor())));
+
+		searchBackgroundColorPickerLabel.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseClicked(MouseEvent e) {
+				Color color = ColorPicker.showDialog(rootComponent, "ColorPicker", new JBColor(new Color(settings.getSearchBackgroundColor()), new Color(settings.getSearchBackgroundColor())), true, new ArrayList<>(), true);
+				if (color != null) {
+					searchBackgroundColorPickerLabel.setBackground(color);
+					settings.setSearchBackgroundColor(color.getRGB());
+				} else {
+					searchBackgroundColorPickerLabel.setBackground(new JBColor(new Color(settings.getSearchBackgroundColor()), new Color(settings.getSearchBackgroundColor())));
+					settings.setSearchBackgroundColor(settings.getSearchBackgroundColor());
+				}
+				super.mouseClicked(e);
+			}
+		});
+
+		conflictsForegroundColorPickerLabel.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseClicked(MouseEvent e) {
+				Color color = ColorPicker.showDialog(rootComponent, "ColorPicker", new JBColor(new Color(settings.getConflictsForegroundColor()), new Color(settings.getConflictsForegroundColor())), true, new ArrayList<>(), true);
+				if (color != null) {
+					conflictsForegroundColorPickerLabel.setBackground(color);
+					settings.setConflictsForegroundColor(color.getRGB());
+				} else {
+					conflictsForegroundColorPickerLabel.setBackground(new JBColor(new Color(settings.getConflictsForegroundColor()), new Color(settings.getConflictsForegroundColor())));
+					settings.setConflictsForegroundColor(settings.getConflictsForegroundColor());
+				}
+				super.mouseClicked(e);
+			}
+		});
 	}
 
 

--- a/src/main/java/krasa/mavenhelper/model/ApplicationSettings.java
+++ b/src/main/java/krasa/mavenhelper/model/ApplicationSettings.java
@@ -2,6 +2,8 @@ package krasa.mavenhelper.model;
 
 import com.intellij.execution.actions.ConfigurationContext;
 import com.intellij.psi.PsiFile;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.xmlb.annotations.Transient;
 import com.rits.cloning.Cloner;
 import krasa.mavenhelper.ApplicationService;
@@ -29,6 +31,10 @@ public class ApplicationSettings extends DomainObject implements Cloneable {
 	private Aliases aliases = new Aliases();
 	private boolean enableDelete = true;
 	private boolean resolveWorkspaceArtifacts = false;
+	private int searchBackgroundColor = JBColor.CYAN.getRGB();
+	private int conflictsForegroundColor = JBColor.RED.getRGB();
+	private SimpleTextAttributes errorAttributes = new SimpleTextAttributes(0, new JBColor(this.getConflictsForegroundColor(), this.getConflictsForegroundColor()));
+	private SimpleTextAttributes errorBoldAttributes = new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, this.getErrorAttributes().getFgColor());
 
 	public ApplicationSettings() {
 		Goals pluginAwareGoals = new Goals();
@@ -199,5 +205,31 @@ public class ApplicationSettings extends DomainObject implements Cloneable {
 
 	public void setResolveWorkspaceArtifacts(boolean resolveWorkspaceArtifacts) {
 		this.resolveWorkspaceArtifacts = resolveWorkspaceArtifacts;
+	}
+
+	public int getSearchBackgroundColor() {
+		return searchBackgroundColor;
+	}
+
+	public void setSearchBackgroundColor(int searchBackgroundColor) {
+		this.searchBackgroundColor = searchBackgroundColor;
+	}
+
+	public int getConflictsForegroundColor() {
+		return conflictsForegroundColor;
+	}
+
+	public void setConflictsForegroundColor(int conflictsForegroundColor) {
+		this.conflictsForegroundColor = conflictsForegroundColor;
+		this.errorAttributes = new SimpleTextAttributes(0, new JBColor(conflictsForegroundColor, conflictsForegroundColor));
+		this.errorBoldAttributes = new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, this.errorAttributes.getFgColor());
+	}
+
+	public SimpleTextAttributes getErrorAttributes() {
+		return errorAttributes;
+	}
+
+	public SimpleTextAttributes getErrorBoldAttributes() {
+		return errorBoldAttributes;
 	}
 }


### PR DESCRIPTION
Hello krasa, I think the default search background color and the font color of conflict items are dazzling and not very friendly, so I added and modified the following two functions
1. Added search background color and conflict foreground color selector at the bottom of the settings panel
2. Apply the search background color and conflict foreground color in the Dependency Analyzer view