### PR TITLE
#103 Persist CheckBoxes state of Dependency Analyzer UI

### DIFF
--- a/src/main/java/krasa/mavenhelper/analyzer/GuiForm.java
+++ b/src/main/java/krasa/mavenhelper/analyzer/GuiForm.java
@@ -66,6 +66,9 @@ public class GuiForm implements Disposable {
 		}
 	};
 	private static final String LAST_RADIO_BUTTON = "MavenHelper.lastRadioButton";
+	private static final String LAST_SHOW_GROUP_ID_CHECKBOX = "MavenHelper.lastShowGroupIdCheckBox";
+	private static final String LAST_SHOW_SIZE_CHECKBOX = "MavenHelper.lastShowSizeCheckBox";
+	private static final String LAST_FILTER_CHECKBOX = "MavenHelper.lastFilterCheckBox";
 	public static final SimpleTextAttributes SIZE_ATTRIBUTES = SimpleTextAttributes.GRAY_ATTRIBUTES;
 
 	private final Project project;
@@ -250,25 +253,25 @@ public class GuiForm implements Disposable {
 		leftPanelList.addMouseListener(leftPanelListPopupHandler);
 		leftPanelList.addKeyListener(new ListKeyStrokeAdapter(this));
 
-		showGroupId.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				RestoreSelection restoreSelection = new RestoreSelection(leftPanelList, leftTree);
-				updateLeftPanel();
-				restoreSelection.restore();
-			}
+		showGroupId.addActionListener((event) -> {
+			final RestoreSelection restoreSelection = new RestoreSelection(leftPanelList, leftTree);
+			updateLeftPanel();
+			restoreSelection.restore();
+			PropertiesComponent.getInstance().setValue(LAST_SHOW_GROUP_ID_CHECKBOX, showGroupId.isSelected());
 		});
 
 		showSize.addActionListener((event) -> {
 			RestoreSelection restoreSelection = new RestoreSelection(leftPanelList, leftTree);
 			updateLeftPanel();
 			restoreSelection.restore();
+			PropertiesComponent.getInstance().setValue(LAST_SHOW_SIZE_CHECKBOX, showSize.isSelected());
 		});
 
 		filter.addActionListener((event) -> {
 			RestoreSelection restoreSelection = new RestoreSelection(leftPanelList, leftTree);
 			updateLeftPanel();
 			restoreSelection.restore();
+			PropertiesComponent.getInstance().setValue(LAST_FILTER_CHECKBOX, filter.isSelected());
 		});
 
 		final DefaultTreeExpander treeExpander = new DefaultTreeExpander(leftTree);
@@ -288,6 +291,9 @@ public class GuiForm implements Disposable {
 		} else {
 			conflictsRadioButton.setSelected(true);
 		}
+		showGroupId.setSelected(Boolean.parseBoolean(PropertiesComponent.getInstance().getValue(LAST_SHOW_GROUP_ID_CHECKBOX)));
+		showSize.setSelected(Boolean.parseBoolean(PropertiesComponent.getInstance().getValue(LAST_SHOW_SIZE_CHECKBOX)));
+		filter.setSelected(Boolean.parseBoolean(PropertiesComponent.getInstance().getValue(LAST_FILTER_CHECKBOX)));
 		Donate.init(donate);
 
 


### PR DESCRIPTION
In most cases, I prefer the "Filter" option to be checked. But this setting is never persisted when I re-open a POM file (possibly, the other check boxes either). It would improve my personal user experience when this setting will be saved.

![grafik](https://user-images.githubusercontent.com/1343053/227886855-4d4e9538-6bab-4359-9425-407b955f9f2e.png)

See: https://github.com/krasa/MavenHelper/issues/103