### PR TITLE
Fix PluginException: avoid calling findProject() inside a read action

### DIFF
--- a/src/main/java/krasa/mavenhelper/analyzer/MyFileEditorProvider.java
+++ b/src/main/java/krasa/mavenhelper/analyzer/MyFileEditorProvider.java
@@ -34,7 +34,10 @@ public class MyFileEditorProvider implements FileEditorProvider, DumbAware {
 		if (!isPotentialPomFile(name)) return false;
 
 		MavenProjectsManager instance = MavenProjectsManager.getInstance(project);
-		final MavenProject mavenProject = instance == null ? null : instance.findProject(file);
+		// Guard against calling findProject() before the project tree is initialized, as that triggers
+		// doInitTree() which asserts no read access and throws a PluginException when called from a read action.
+		if (instance == null || !instance.isMavenizedProject()) return false;
+		final MavenProject mavenProject = instance.findProject(file);
 		if (mavenProject != null) {
 			return mavenProject.getFile().equals(file);
 		}
@@ -52,7 +55,9 @@ public class MyFileEditorProvider implements FileEditorProvider, DumbAware {
 //		https://github.com/krasa/MavenHelper/issues/130
 //		LOG.assertTrue(accept(project, file));
 
-		return new UIFormEditor(project, file);
+		MavenProjectsManager instance = MavenProjectsManager.getInstance(project);
+		MavenProject mavenProject = (instance != null && instance.isMavenizedProject()) ? instance.findProject(file) : null;
+		return new UIFormEditor(project, file, mavenProject);
 	}
 
 	@Override

--- a/src/main/java/krasa/mavenhelper/analyzer/MyHighlightingTree.java
+++ b/src/main/java/krasa/mavenhelper/analyzer/MyHighlightingTree.java
@@ -41,10 +41,10 @@ public class MyHighlightingTree extends Tree implements DataProvider {
 		if (object instanceof MyTreeUserObject) {
 			if (((MyTreeUserObject) object).isHighlight()) {
 				ApplicationSettings state = MavenHelperApplicationService.getInstance().getState();
-				if (UIUtil.isUnderDarcula()) {
-					return darker(new JBColor(new Color(state.getSearchBackgroundColor()), new Color(state.getSearchBackgroundColor())), 8);
-				} else {
+				if (JBColor.isBright()) {
 					return softer(new JBColor(new Color(state.getSearchBackgroundColor()), new Color(state.getSearchBackgroundColor())));
+				} else {
+					return darker(new JBColor(new Color(state.getSearchBackgroundColor()), new Color(state.getSearchBackgroundColor())), 8);
 				}
 			}
 		}

--- a/src/main/java/krasa/mavenhelper/analyzer/UIFormEditor.java
+++ b/src/main/java/krasa/mavenhelper/analyzer/UIFormEditor.java
@@ -10,8 +10,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.UserDataHolderBase;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.maven.project.MavenProject;
-import org.jetbrains.idea.maven.project.MavenProjectsManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,9 +30,8 @@ public final class UIFormEditor extends UserDataHolderBase implements /* Navigat
 	private final VirtualFile file;
 	private GuiForm myEditor;
 
-	public UIFormEditor(@NotNull Project project, final VirtualFile file) {
+	public UIFormEditor(@NotNull Project project, final VirtualFile file, @Nullable MavenProject mavenProject) {
 		this.file = file;
-		final MavenProject mavenProject = MavenProjectsManager.getInstance(project).findProject(file);
 		if (mavenProject != null) {
 			myEditor = new GuiForm(project, file, mavenProject);
 		} else {


### PR DESCRIPTION
Guard createEditor() and isPomFile() with isMavenizedProject() so that MavenProjectsManager.getProjectsTree() is never triggered before the project tree is initialized, which would call doInitTree() and fail with 'Must not execute inside read action'.

Fixes https://github.com/krasa/MavenHelper/issues/140